### PR TITLE
feat(web): init react app

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,0 +1,47 @@
+import os
+import logging
+from typing import Any, Dict
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from .middleware import request_id_middleware
+from .services.parse_service import parse_spec_file, parse_config_file
+from .services.validate_service import validate
+from .schemas import ValidationResponse
+
+logging.basicConfig(level=logging.INFO)
+app = FastAPI()
+app.middleware('http')(request_id_middleware)
+
+origins = [os.getenv('WEB_ORIGIN', 'http://localhost:5173')]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=['*'],
+    allow_headers=['*'],
+)
+
+jobs: Dict[str, Dict[str, Any]] = {}
+
+@app.post('/specs:upload')
+async def upload_spec(file: UploadFile = File(...), jobId: str = 'default'):
+    content = await file.read()
+    spec = parse_spec_file(content, file.filename)
+    job = jobs.setdefault(jobId, {})
+    job['spec'] = spec
+    return {'jobId': jobId, 'status': 'spec uploaded'}
+
+@app.post('/configs:upload')
+async def upload_config(file: UploadFile = File(...), jobId: str = 'default'):
+    content = await file.read()
+    conf = parse_config_file(content.decode())
+    job = jobs.setdefault(jobId, {})
+    job['conf'] = conf
+    return {'jobId': jobId, 'status': 'config uploaded'}
+
+@app.post('/validate', response_model=ValidationResponse)
+async def validate_job(jobId: str = 'default'):
+    job = jobs.get(jobId)
+    if not job or 'spec' not in job or 'conf' not in job:
+        raise HTTPException(status_code=400, detail='spec or config missing')
+    return validate(job['spec'], job['conf'])

--- a/apps/api/app/middleware.py
+++ b/apps/api/app/middleware.py
@@ -1,0 +1,10 @@
+from uuid import uuid4
+from typing import Callable
+from fastapi import Request, Response
+
+async def request_id_middleware(request: Request, call_next: Callable):
+    request_id = str(uuid4())
+    request.state.request_id = request_id
+    response: Response = await call_next(request)
+    response.headers['X-Request-ID'] = request_id
+    return response

--- a/apps/api/app/parsers/ontap_cli.yaml
+++ b/apps/api/app/parsers/ontap_cli.yaml
@@ -1,0 +1,17 @@
+parsers:
+  - name: ontap_version
+    match: "NetApp Release\s+(?P<version>[\w\.]+)"
+    map:
+      cluster.version: "{version}"
+
+  - name: bmc_ipv4
+    match: "IPv4\s+(?P<ip>\d+\.\d+\.\d+\.\d+)\s+(?P<netmask>\d+\.\d+\.\d+\.\d+)\s+(?P<gateway>\d+\.\d+\.\d+\.\d+)"
+    map:
+      nodes[0].bmc.ip: "{ip}"
+      nodes[0].bmc.netmask: "{netmask}"
+      nodes[0].bmc.gateway: "{gateway}"
+
+  - name: disk_models
+    match: "(?ms)disk show -fields model.*?\n(?P<table>.+?)\n\d+ entries were displayed\."
+    map:
+      nodes[0].disks[].model: "table_to_list"

--- a/apps/api/app/rulesets/default.yaml
+++ b/apps/api/app/rulesets/default.yaml
@@ -1,0 +1,27 @@
+rules:
+  - id: R-002
+    level: P0
+    title: ONTAP version equals expected
+    path_spec: spec.cluster.expected_version
+    path_conf: conf.cluster.version
+    compare:
+      - field: version
+        op: eq
+
+  - id: R-001-bmc-ip
+    level: P0
+    title: BMC IP matches
+    path_spec: spec.nodes[0].bmc.ip
+    path_conf: conf.nodes[0].bmc.ip
+    compare:
+      - field: value
+        op: eq
+
+  - id: R-101-disk-model
+    level: P1
+    title: Disk model belongs to allowed list
+    path_spec: spec.allowed_disk_models
+    path_conf: conf.nodes[0].disks[].model
+    compare:
+      - field: any_in
+        args: { mode: allow }

--- a/apps/api/app/schemas.py
+++ b/apps/api/app/schemas.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+from typing import List, Literal, Optional
+
+class ValidationDiff(BaseModel):
+    id: str
+    level: Literal['P0', 'P1', 'P2']
+    status: Literal['PASS', 'FAIL', 'WARN']
+    message: str
+    expected: Optional[str] = None
+    actual: Optional[str] = None
+
+class ValidationSummary(BaseModel):
+    pass_: int
+    fail: int
+    warn: int
+
+class ValidationResponse(BaseModel):
+    summary: ValidationSummary
+    diffs: List[ValidationDiff]

--- a/apps/api/app/services/parse_service.py
+++ b/apps/api/app/services/parse_service.py
@@ -1,0 +1,74 @@
+import json
+import csv
+import re
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Dict
+import yaml
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+PARSER_PATH = BASE_DIR / 'parsers' / 'ontap_cli.yaml'
+
+def parse_spec_file(data: bytes, filename: str) -> Dict[str, Any]:
+    if filename.endswith('.json'):
+        return json.load(BytesIO(data))
+    elif filename.endswith('.csv'):
+        text = data.decode('utf-8')
+        reader = csv.DictReader(text.splitlines())
+        return {'rows': list(reader)}
+    else:
+        raise ValueError('unsupported spec format')
+
+def table_to_list(table: str) -> list[str]:
+    lines = [l.strip() for l in table.strip().splitlines() if l.strip()]
+    models: list[str] = []
+    for line in lines[1:]:  # skip header
+        parts = re.split(r'\s+', line)
+        if parts:
+            models.append(parts[-1])
+    return models
+
+def set_path(data: Dict[str, Any], path: str, value: Any) -> None:
+    parts = path.split('.')
+    cur: Any = data
+    for part in parts[:-1]:
+        if part.endswith('[]'):
+            key = part[:-2]
+            cur.setdefault(key, [])
+            new_elem = {}
+            cur[key].append(new_elem)
+            cur = new_elem
+        elif '[' in part and part.endswith(']'):
+            key, idx = part[:-1].split('[')
+            idx = int(idx)
+            cur.setdefault(key, [])
+            while len(cur[key]) <= idx:
+                cur[key].append({})
+            cur = cur[key][idx]
+        else:
+            cur = cur.setdefault(part, {})
+    last = parts[-1]
+    if last.endswith('[]'):
+        key = last[:-2]
+        cur.setdefault(key, [])
+        cur[key].append(value)
+    else:
+        cur[last] = value
+
+def parse_config_file(text: str) -> Dict[str, Any]:
+    with open(PARSER_PATH, 'r', encoding='utf-8') as f:
+        config = yaml.safe_load(f)
+    data: Dict[str, Any] = {}
+    for parser in config.get('parsers', []):
+        match = re.search(parser['match'], text, re.MULTILINE)
+        if not match:
+            continue
+        for path, tmpl in parser.get('map', {}).items():
+            if tmpl == 'table_to_list':
+                table = match.group('table')
+                for item in table_to_list(table):
+                    set_path(data, path, item)
+            else:
+                value = tmpl.format(**match.groupdict())
+                set_path(data, path, value)
+    return data

--- a/apps/api/app/services/validate_service.py
+++ b/apps/api/app/services/validate_service.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+from typing import Any, Dict, List
+import yaml
+from ..schemas import ValidationDiff, ValidationResponse, ValidationSummary
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+RULESET_PATH = BASE_DIR / 'rulesets' / 'default.yaml'
+
+def get_values(data: Any, path: str) -> List[Any]:
+    parts = path.split('.')
+    values = [data]
+    for part in parts:
+        if part.endswith('[]'):
+            key = part[:-2]
+            new_vals: List[Any] = []
+            for v in values:
+                arr = v.get(key, []) if isinstance(v, dict) else []
+                if isinstance(arr, list):
+                    new_vals.extend(arr)
+            values = new_vals
+        elif '[' in part and part.endswith(']'):
+            key, idx = part[:-1].split('[')
+            idx = int(idx)
+            new_vals = []
+            for v in values:
+                arr = v.get(key, []) if isinstance(v, dict) else []
+                if isinstance(arr, list) and len(arr) > idx:
+                    new_vals.append(arr[idx])
+            values = new_vals
+        else:
+            new_vals = []
+            for v in values:
+                if isinstance(v, dict) and part in v:
+                    new_vals.append(v[part])
+            values = new_vals
+    return values
+
+def validate(spec: Dict[str, Any], conf: Dict[str, Any]) -> ValidationResponse:
+    with open(RULESET_PATH, 'r', encoding='utf-8') as f:
+        rules = yaml.safe_load(f).get('rules', [])
+    diffs: List[ValidationDiff] = []
+    pass_count = fail_count = warn_count = 0
+    ctx = {'spec': spec, 'conf': conf}
+    for rule in rules:
+        expected_vals = get_values(ctx, rule['path_spec'])
+        conf_vals = get_values(ctx, rule['path_conf'])
+        compare = rule['compare'][0]
+        op = compare.get('op')
+        status = 'PASS'
+        message = rule['title']
+        expected_str = actual_str = None
+        if op == 'eq':
+            expected = expected_vals[0] if expected_vals else None
+            actual = conf_vals[0] if conf_vals else None
+            expected_str = str(expected)
+            actual_str = str(actual)
+            if expected != actual:
+                status = 'FAIL'
+        elif op == 'any_in':
+            allowed = expected_vals[0] if expected_vals else []
+            actual_list = conf_vals
+            if not all(item in allowed for item in actual_list):
+                status = 'FAIL'
+        else:
+            status = 'WARN'
+        if status == 'PASS':
+            pass_count += 1
+        elif status == 'FAIL':
+            fail_count += 1
+        else:
+            warn_count += 1
+        diffs.append(
+            ValidationDiff(
+                id=rule['id'],
+                level=rule['level'],
+                status=status,
+                message=message,
+                expected=expected_str,
+                actual=actual_str,
+            )
+        )
+    summary = ValidationSummary(pass_=pass_count, fail=fail_count, warn=warn_count)
+    return ValidationResponse(summary=summary, diffs=diffs)

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "scv-api"
+version = "0.1.0"
+description = "Spec vs Config Validator API"
+authors = ["SCV Team <scv@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.111.0"
+uvicorn = { extras = ["standard"], version = "^0.30.0" }
+pydantic = "^2.6.0"
+pyyaml = "^6.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.1.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/apps/api/run.py
+++ b/apps/api/run.py
@@ -1,0 +1,4 @@
+import uvicorn
+
+if __name__ == '__main__':
+    uvicorn.run('app.main:app', host='0.0.0.0', port=8000)

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spec vs Config Validator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@scv/web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint .",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.0.2",
+    "@radix-ui/react-tooltip": "^1.0.7",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.0.0",
+    "lucide-react": "^0.293.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "tailwind-merge": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.3.1",
+    "jsdom": "^23.0.0"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom';
+import Dashboard from './pages/Dashboard';
+import Validate from './pages/Validate';
+import Rules from './pages/Rules';
+import { I18nProvider, useI18n } from './lib/i18n';
+
+function Nav() {
+  const { t, lang, setLang } = useI18n();
+  return (
+    <header className="shadow-sm mb-4">
+      <nav className="container mx-auto flex items-center justify-between py-4">
+        <div className="flex gap-4">
+          <NavLink to="/" className="font-medium" end>
+            {t('nav.dashboard')}
+          </NavLink>
+          <NavLink to="/validate" className="font-medium">
+            {t('nav.validate')}
+          </NavLink>
+          <NavLink to="/rules" className="font-medium">
+            {t('nav.rules')}
+          </NavLink>
+        </div>
+        <select
+          className="border rounded-md px-2 py-1"
+          value={lang}
+          onChange={(e) => setLang(e.target.value as any)}
+        >
+          <option value="zh-TW">中文</option>
+          <option value="en-US">EN</option>
+        </select>
+      </nav>
+    </header>
+  );
+}
+
+export default function App() {
+  return (
+    <I18nProvider>
+      <BrowserRouter>
+        <Nav />
+        <main className="container mx-auto p-4">
+          <Routes>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/validate" element={<Validate />} />
+            <Route path="/rules" element={<Rules />} />
+          </Routes>
+        </main>
+      </BrowserRouter>
+    </I18nProvider>
+  );
+}

--- a/apps/web/src/components/DiffTable.tsx
+++ b/apps/web/src/components/DiffTable.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Badge } from './ui/badge';
+import { Table, Thead, Tbody, Tr, Th, Td } from './ui/table';
+import type { ValidationDiff } from '../lib/types';
+
+interface Props {
+  diffs: ValidationDiff[];
+}
+
+export default function DiffTable({ diffs }: Props) {
+  return (
+    <Table>
+      <Thead>
+        <Tr>
+          <Th>ID</Th>
+          <Th>Level</Th>
+          <Th>Status</Th>
+          <Th>Message</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {diffs.map((d) => (
+          <Tr key={d.id}>
+            <Td>{d.id}</Td>
+            <Td>{d.level}</Td>
+            <Td>
+              <Badge
+                variant={
+                  d.status === 'PASS'
+                    ? 'success'
+                    : d.status === 'WARN'
+                    ? 'warning'
+                    : 'destructive'
+                }
+              >
+                {d.status}
+              </Badge>
+            </Td>
+            <Td>{d.message}</Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  );
+}

--- a/apps/web/src/components/ParsersHelp.tsx
+++ b/apps/web/src/components/ParsersHelp.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
+import { Info } from 'lucide-react';
+
+export default function ParsersHelp() {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger className="inline-flex items-center cursor-pointer">
+          <Info className="h-4 w-4" />
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Supported parsers: ontap_cli</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/src/components/RuleBadge.tsx
+++ b/apps/web/src/components/RuleBadge.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Badge } from './ui/badge';
+
+interface Props {
+  level: 'P0' | 'P1' | 'P2';
+}
+
+const levelMap: Record<Props['level'], 'destructive' | 'warning' | 'default'> = {
+  P0: 'destructive',
+  P1: 'warning',
+  P2: 'default',
+};
+
+export default function RuleBadge({ level }: Props) {
+  return <Badge variant={levelMap[level]}>{level}</Badge>;
+}

--- a/apps/web/src/components/SummaryCards.tsx
+++ b/apps/web/src/components/SummaryCards.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from './ui/card';
+
+interface Props {
+  pass: number;
+  fail: number;
+  warn: number;
+}
+
+export default function SummaryCards({ pass, fail, warn }: Props) {
+  const items = [
+    { label: 'PASS', value: pass },
+    { label: 'FAIL', value: fail },
+    { label: 'WARN', value: warn },
+  ];
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      {items.map((item) => (
+        <Card key={item.label}>
+          <CardHeader>
+            <CardTitle>{item.label}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">{item.value}</p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/UploadWizard.tsx
+++ b/apps/web/src/components/UploadWizard.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { uploadSpec, uploadConfig, validateJob } from '../lib/api';
+import { useI18n } from '../lib/i18n';
+
+export default function UploadWizard() {
+  const { t } = useI18n();
+  const [spec, setSpec] = useState<File | null>(null);
+  const [conf, setConf] = useState<File | null>(null);
+  const [jobId, setJobId] = useState('default');
+
+  async function handleUpload() {
+    if (spec) await uploadSpec(spec);
+    if (conf) await uploadConfig(conf);
+    await validateJob(jobId);
+  }
+
+  return (
+    <div className="space-y-4">
+      <Input type="file" onChange={(e) => setSpec(e.target.files?.[0] || null)} />
+      <Input type="file" onChange={(e) => setConf(e.target.files?.[0] || null)} />
+      <Button onClick={handleUpload} disabled={!spec || !conf}>
+        {t('validate.upload')}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground border-transparent',
+        secondary: 'bg-secondary text-secondary-foreground border-transparent',
+        destructive: 'bg-destructive text-destructive-foreground border-transparent',
+        outline: 'text-foreground',
+        success: 'bg-green-500 text-white border-transparent',
+        warning: 'bg-yellow-400 text-black border-transparent',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'underline-offset-4 hover:underline text-primary',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-2xl border bg-card text-card-foreground shadow', className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => <div ref={ref} className={cn('p-4', className)} {...props} />
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn('text-lg font-semibold leading-none', className)} {...props} />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => <div ref={ref} className={cn('p-4 pt-0', className)} {...props} />
+);
+CardContent.displayName = 'CardContent';
+
+export { Card, CardHeader, CardTitle, CardContent };

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = 'Input';
+
+export { Input };

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="w-full overflow-auto">
+      <table
+        ref={ref}
+        className={cn('w-full caption-bottom text-sm', className)}
+        {...props}
+      />
+    </div>
+  )
+);
+Table.displayName = 'Table';
+
+const Thead = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <thead ref={ref} className={cn('[&>tr]:border-b', className)} {...props} />
+  )
+);
+Thead.displayName = 'Thead';
+
+const Tbody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => <tbody ref={ref} className={cn('border-b', className)} {...props} />
+);
+Tbody.displayName = 'Tbody';
+
+const Tr = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn('border-b transition-colors hover:bg-muted/50', className)}
+      {...props}
+    />
+  )
+);
+Tr.displayName = 'Tr';
+
+const Th = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th
+      ref={ref}
+      className={cn('h-10 px-2 text-left align-middle font-medium text-muted-foreground sticky top-0 bg-background', className)}
+      {...props}
+    />
+  )
+);
+Th.displayName = 'Th';
+
+const Td = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => <td ref={ref} className={cn('p-2 align-middle', className)} {...props} />
+);
+Td.displayName = 'Td';
+
+export { Table, Thead, Tbody, Tr, Th, Td };

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { cn } from '../../lib/utils';
+
+const TooltipProvider = TooltipPrimitive.Provider;
+const Tooltip = TooltipPrimitive.Root;
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95',
+      className
+    )}
+    {...props}
+  />
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent };

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,0 +1,25 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --ring: 215 20.2% 65.1%;
+  }
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,31 @@
+export const API_BASE = import.meta.env.VITE_API_BASE || '/api';
+
+export async function uploadSpec(file: File) {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch(`${API_BASE}/specs:upload`, {
+    method: 'POST',
+    body: form,
+  });
+  if (!res.ok) throw new Error('spec upload failed');
+  return res.json();
+}
+
+export async function uploadConfig(file: File) {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch(`${API_BASE}/configs:upload`, {
+    method: 'POST',
+    body: form,
+  });
+  if (!res.ok) throw new Error('config upload failed');
+  return res.json();
+}
+
+export async function validateJob(jobId: string) {
+  const res = await fetch(`${API_BASE}/validate?jobId=${jobId}`, {
+    method: 'POST',
+  });
+  if (!res.ok) throw new Error('validation failed');
+  return res.json();
+}

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useState } from 'react';
+
+type Lang = 'en-US' | 'zh-TW';
+
+type Dict = Record<Lang, Record<string, string>>;
+
+const dict: Dict = {
+  'en-US': {
+    'nav.dashboard': 'Dashboard',
+    'nav.validate': 'Validate',
+    'nav.rules': 'Rules',
+    'dashboard.welcome': 'Welcome to Spec vs Config Validator',
+    'validate.upload': 'Upload and Validate',
+    'rules.placeholder': 'Rules editor coming soon.',
+  },
+  'zh-TW': {
+    'nav.dashboard': '儀表板',
+    'nav.validate': '驗證',
+    'nav.rules': '規則',
+    'dashboard.welcome': '歡迎使用規格與設定驗證器',
+    'validate.upload': '上傳並驗證',
+    'rules.placeholder': '規則編輯器即將推出',
+  },
+};
+
+interface I18nContextType {
+  lang: Lang;
+  t: (key: string) => string;
+  setLang: (lang: Lang) => void;
+}
+
+const I18nContext = createContext<I18nContextType | undefined>(undefined);
+
+export const I18nProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [lang, setLang] = useState<Lang>('zh-TW');
+  const t = (key: string) => dict[lang][key] ?? key;
+  return <I18nContext.Provider value={{ lang, t, setLang }}>{children}</I18nContext.Provider>;
+};
+
+export function useI18n() {
+  const ctx = useContext(I18nContext);
+  if (!ctx) throw new Error('useI18n must be used within I18nProvider');
+  return ctx;
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,0 +1,8 @@
+export interface ValidationDiff {
+  id: string;
+  level: 'P0' | 'P1' | 'P2';
+  status: 'PASS' | 'FAIL' | 'WARN';
+  message: string;
+  expected?: string;
+  actual?: string;
+}

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { useI18n } from '../lib/i18n';
+
+export default function Dashboard() {
+  const { t } = useI18n();
+  return <div>{t('dashboard.welcome')}</div>;
+}

--- a/apps/web/src/pages/Rules.tsx
+++ b/apps/web/src/pages/Rules.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { useI18n } from '../lib/i18n';
+
+export default function Rules() {
+  const { t } = useI18n();
+  return <div>{t('rules.placeholder')}</div>;
+}

--- a/apps/web/src/pages/Validate.tsx
+++ b/apps/web/src/pages/Validate.tsx
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+import UploadWizard from '../components/UploadWizard';
+import SummaryCards from '../components/SummaryCards';
+import DiffTable from '../components/DiffTable';
+import type { ValidationDiff } from '../lib/types';
+
+export default function Validate() {
+  const [diffs] = useState<ValidationDiff[]>([]);
+  return (
+    <div className="space-y-6">
+      <UploadWizard />
+      <SummaryCards pass={0} fail={0} warn={0} />
+      <DiffTable diffs={diffs} />
+    </div>
+  );
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      borderRadius: {
+        lg: '0.5rem',
+        xl: '0.75rem',
+        '2xl': '1rem',
+      },
+    },
+  },
+  plugins: [require('tailwindcss-animate')],
+};
+export default config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "tailwind.config.ts"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': process.env.VITE_API_PROXY || 'http://localhost:8000',
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold React web app with Vite + TypeScript
- add Tailwind and shadcn/ui base components
- implement navigation shell with basic i18n and placeholders

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c11b45912c832d852e557342f944f6